### PR TITLE
Add missing typedef in gdnative_interface.h

### DIFF
--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -181,11 +181,11 @@ typedef void *(*GDNativeInstanceBindingCreateCallback)(void *p_token, void *p_in
 typedef void (*GDNativeInstanceBindingFreeCallback)(void *p_token, void *p_instance, void *p_binding);
 typedef GDNativeBool (*GDNativeInstanceBindingReferenceCallback)(void *p_token, void *p_binding, GDNativeBool p_reference);
 
-struct GDNativeInstanceBindingCallbacks {
+typedef struct {
 	GDNativeInstanceBindingCreateCallback create_callback;
 	GDNativeInstanceBindingFreeCallback free_callback;
 	GDNativeInstanceBindingReferenceCallback reference_callback;
-};
+} GDNativeInstanceBindingCallbacks;
 
 /* EXTENSION CLASSES */
 


### PR DESCRIPTION
Without this change the signatures of `object_get_instance_binding` and `object_set_instance_binding` don't compile properly in C mode because the `struct` keyword is missing. The added `typedef` makes the definition look like others in the file.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
